### PR TITLE
Switch CLI flag solution to spf13/pflag

### DIFF
--- a/src/sync/ws/go/.gitignore
+++ b/src/sync/ws/go/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+p2p-live-share-ws-server
 ws-server
 *.exe
 *.test

--- a/src/sync/ws/go/go.mod
+++ b/src/sync/ws/go/go.mod
@@ -2,4 +2,7 @@ module p2p-live-share-ws-server
 
 go 1.21
 
-require github.com/gorilla/websocket v1.5.3
+require (
+	github.com/gorilla/websocket v1.5.3
+	github.com/spf13/pflag v1.0.10
+)

--- a/src/sync/ws/go/go.sum
+++ b/src/sync/ws/go/go.sum
@@ -1,2 +1,4 @@
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=


### PR DESCRIPTION
It handles long and short flags together, while also providing a customizable `Usage` function. This makes flag handling much simpler.