### PR TITLE
fix: don't deliver a host's own messages back to itself in host mode

### DIFF
--- a/src/sync/ws/server.ts
+++ b/src/sync/ws/server.ts
@@ -171,7 +171,10 @@ class WebSocketSignalingServer {
       ? Array.isArray(uplink.targetPeers) ? uplink.targetPeers : [uplink.targetPeers]
       : undefined
 
-    if (this.options.hostMode) {
+    // Never echo a message back to its sender, mirroring the `peerId !== senderId`
+    // guard on the WebSocket clients below. In host mode the host is not a WebSocket
+    // client, so without this check its own broadcasts are delivered back to itself.
+    if (this.options.hostMode && senderId !== this.options.hostMode.hostId) {
       if (!targets || targets.includes(this.options.hostMode.hostId)) {
         this.options.hostMode.onHostMessage(downlinkPayload)
       }


### PR DESCRIPTION
Fixes #12.

## The problem

`WebSocketSignalingServer.handleMessage` skips the sender when relaying to WebSocket clients:

```ts
if (client && client.data?.peerId !== senderId && client.readyState === WebSocket.OPEN)
```

The host-mode branch just above it has no equivalent guard:

```ts
if (this.options.hostMode) {
  if (!targets || targets.includes(this.options.hostMode.hostId)) {
    this.options.hostMode.onHostMessage(downlinkPayload)
  }
}
```

In host mode the host isn't a WebSocket client — `useWebSocketHostConnection` calls `server.handleMessage(..., selfId)` directly and receives through `onHostMessage`. So every message the host broadcast (`targetPeers` omitted, making `targets` `undefined`) was delivered right back to the host.

## Why it matters

`useHostTerminals` registers `send` and `recv` on the same `terminal` action:

```ts
const [send, recv] = connection.makeAction<string, string>('terminal')
recv((content, _peerId, id) => handleTerminalInput(id!, content))  // -> process.write()
...
process.onOutput((data) => {
  terminal.appendOutput(data)
  send(data, null, id)                                             // broadcast
})
```

With the self-echo, the host's own PTY **output** comes back through `recv` and is written to the PTY as **input**. In a "Host Locally" session the shell's own escape sequences get executed as commands, and since each new prompt emits more of them it compounds until the terminal is unusable:

```
<user>@<host>:~/path$ 0;<user>@<host>:~/path
bash: 0: command not found...
<user>@<host>:~/path$ 2004l
bash: 2004l: command not found...
```

That output is OSC 0 (window title), `CSI ?2004h/l` (bracketed paste) and SGR colour codes — things essentially every interactive prompt emits, so it isn't tied to any unusual shell configuration. It also reproduces with **no guest connected**, since it's purely a host-side loop. Trystero sessions are unaffected, as a peer there can't echo to itself.

Other actions are self-echoed too, but Yjs updates are idempotent, so the terminal is where it actually does damage — which is probably why it went unnoticed.

## The fix

Apply the same sender check the client path already uses. Behaviour is now consistent between the two transports: a peer never receives its own message back, even when it targets itself.

## Verification

Driving the built `handleMessage` directly, before and after:

```
BEFORE (0.1.1):
  host own broadcast echoed back to host : 1   (bug)
  guest->host message delivered          : 1   (good)
AFTER:
  host own broadcast echoed back to host : 0   (good)
  guest->host message delivered          : 1   (good)
```

Also confirmed in a real "Host Locally" session on Linux/VSCodium: shared terminals behave correctly after the change, and guest→host input still reaches the PTY.
