### PR TITLE
fix(ws): prevent host message self-delivery

### DIFF
--- a/package.json
+++ b/package.json
@@ -570,6 +570,7 @@
   },
   "scripts": {
     "build": "tsdown --env.NODE_ENV production --minify --clean",
+    "test": "tsx --test src/**/*.test.ts",
     "dev": "tsdown --watch --env.NODE_ENV development",
     "typecheck": "tsc --noEmit",
     "vscode:prepublish": "pnpm run build",

--- a/src/sync/ws/server.test.ts
+++ b/src/sync/ws/server.test.ts
@@ -1,0 +1,68 @@
+import type { DownlinkMessageContent } from './protocol.ts'
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test
+import { describe, it } from 'node:test'
+import { createServer } from './server.ts'
+
+const hostId = 'host'
+const guestId = 'guest'
+const roomId = 'room'
+const terminalOutput = '\x1B]3008;start=abc;type=shell\x1B\\\x1B[?2004h\x1B[32m$ \x1B[0m'
+
+describe('WebSocketSignalingServer host routing', () => {
+  function setup() {
+    const hostMessages: DownlinkMessageContent[] = []
+    const server = createServer({
+      port: 0,
+      hostname: '127.0.0.1',
+      hostMode: {
+        roomId,
+        hostId,
+        onHostMessage: message => hostMessages.push(message),
+      },
+    })
+    return { hostMessages, server }
+  }
+
+  it('does not deliver host broadcasts back to the host', () => {
+    const { hostMessages, server } = setup()
+
+    server.handleMessage({ action: 'terminal', data: terminalOutput }, roomId, hostId)
+
+    assert.deepEqual(hostMessages, [])
+  })
+
+  it('does not deliver explicitly self-targeted host messages', () => {
+    const { hostMessages, server } = setup()
+
+    server.handleMessage({ action: 'terminal', data: terminalOutput, targetPeers: hostId }, roomId, hostId)
+
+    assert.deepEqual(hostMessages, [])
+  })
+
+  it('delivers guest broadcasts to the host without changing terminal data', () => {
+    const { hostMessages, server } = setup()
+
+    server.handleMessage({ action: 'terminal', data: terminalOutput }, roomId, guestId)
+
+    assert.deepEqual(hostMessages, [{
+      action: 'terminal',
+      data: terminalOutput,
+      peerId: guestId,
+      metadata: undefined,
+    }])
+  })
+
+  it('delivers guest messages targeted at the host', () => {
+    const { hostMessages, server } = setup()
+
+    server.handleMessage({ action: 'terminal', data: 'ls\r', targetPeers: hostId }, roomId, guestId)
+
+    assert.deepEqual(hostMessages, [{
+      action: 'terminal',
+      data: 'ls\r',
+      peerId: guestId,
+      metadata: undefined,
+    }])
+  })
+})

--- a/src/sync/ws/server.ts
+++ b/src/sync/ws/server.ts
@@ -172,7 +172,7 @@ class WebSocketSignalingServer {
       : undefined
 
     if (this.options.hostMode) {
-      if (!targets || targets.includes(this.options.hostMode.hostId)) {
+      if (senderId !== this.options.hostMode.hostId && (!targets || targets.includes(this.options.hostMode.hostId))) {
         this.options.hostMode.onHostMessage(downlinkPayload)
       }
     }


### PR DESCRIPTION
## Summary
- exclude the embedded WebSocket host from its own broadcasts
- preserve guest-to-host broadcast and targeted delivery
- add routing regression coverage with terminal escape-sequence payloads

## Root cause
Host Locally messages bypass the normal WebSocket sender exclusion. Terminal output broadcast by the host was therefore delivered back as terminal input and written into the PTY.

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm exec eslint src/sync/ws/server.ts src/sync/ws/server.test.ts package.json`
- `pnpm build`

Closes #12