### PR TITLE
fix(terminal): find node-pty in node_modules.asar

### DIFF
--- a/src/terminal/pty/shims/node-pty.ts
+++ b/src/terminal/pty/shims/node-pty.ts
@@ -1,4 +1,18 @@
+import type * as NodePty from 'node-pty'
 import { resolveAsset } from './utils'
 
-// eslint-disable-next-line ts/no-require-imports
-module.exports = require(resolveAsset('node-pty/lib/index.js'))
+let nodePty: typeof NodePty | undefined
+
+/**
+ * node-pty is not bundled: the copy shipped inside the editor is reused so the
+ * native binding matches the editor's Electron ABI. Resolving it is deferred to
+ * the first spawn because an editor that does not ship node-pty would otherwise
+ * throw while this module is being evaluated, which takes down the whole
+ * extension at activation instead of only terminal sharing.
+ */
+function load(): typeof NodePty {
+  // eslint-disable-next-line ts/no-require-imports
+  return nodePty ??= require(resolveAsset('node-pty/lib/index.js'))
+}
+
+export const spawn: typeof NodePty.spawn = (file, args, options) => load().spawn(file, args, options)

--- a/src/terminal/pty/shims/utils.ts
+++ b/src/terminal/pty/shims/utils.ts
@@ -1,14 +1,32 @@
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { window } from 'vscode'
 import { getAppRoot } from '../utils.js'
 
-export function resolveAsset(path: string) {
+/**
+ * VS Code 1.130 moved the dependencies it ships from a plain `node_modules`
+ * directory into `node_modules.asar`, keeping only a handful of packages in the
+ * former. Electron resolves `require` and `existsSync` inside the archive
+ * transparently, and redirects native `.node` files to the sibling
+ * `node_modules.asar.unpacked`, so both roots can be probed the same way.
+ */
+const assetRoots = ['../node_modules', '../node_modules.asar']
+
+function tryResolveAsset(path: string): string | undefined {
   const appRoot = getAppRoot()
-  const resolved = resolve(appRoot, '../node_modules', path)
-  if (!existsSync(resolved)) {
-    window.showErrorMessage(`Asset not found: ${path}`)
-    throw new Error(`Asset not found: ${path}`)
+  for (const root of assetRoots) {
+    const resolved = resolve(appRoot, root, path)
+    if (existsSync(resolved)) {
+      return resolved
+    }
+  }
+  return undefined
+}
+
+export function resolveAsset(path: string): string {
+  const resolved = tryResolveAsset(path)
+  if (!resolved) {
+    const searched = assetRoots.map(root => resolve(getAppRoot(), root)).join(', ')
+    throw new Error(`Asset not found: ${path} (searched ${searched})`)
   }
   return resolved
 }


### PR DESCRIPTION
Closes #16.

## Problem

The extension fails to activate on VS Code 1.130+. Panel spins forever, no commands registered:

    Error: Asset not found: node-pty/lib/index.js

## Cause

node-pty isn't bundled — the editor's copy is reused so the native binding matches its Electron ABI. But it was only looked for in `<appRoot>/../node_modules`, and 1.130 moved bundled deps into `node_modules.asar`. On 1.132.0 the plain directory keeps just 5 packages; node-pty is in the archive.

The failure is fatal because `shims/node-pty.ts` did its `require` at module scope, so the throw happens while `dist/extension.cjs` is still being evaluated — before `activate` runs. That kills the whole extension, not just terminal sharing.

## Fix

- Probe `node_modules.asar` as well. Electron resolves `require` and `existsSync` inside the archive and redirects native `.node` files to `node_modules.asar.unpacked`, so the editor's own binding is used as before.
- Load node-pty on first spawn instead of at module scope, so a missing binding costs shared terminals rather than the whole extension.

`@vscode/windows-process-tree` shares the resolver and is already lazily imported behind a `win32` guard, so it needs no change.

## Verification

On VS Code 1.132.0 (Electron 42.7.1, ABI 146), loading the built `dist/` with a stubbed `vscode`: before, `extension.cjs` throws while loading; after, it loads, resolves to `.../node_modules.asar/node-pty/lib/index.js`, and spawns a real pty successfully.

`pnpm typecheck`, `build` and `test` (4/4) pass. Remaining lint errors in `README.md` and `src/extension.ts` are pre-existing on `main`.

## Note on #17

#17 fixes the lookup too, but bundles an unrelated `Y.UndoManager` feature and leaves the `require` at module scope, so editors shipping no node-pty still fail activation outright. This PR is activation-only if you'd prefer to ship #16 as a patch release — happy to defer or rebase otherwise.
